### PR TITLE
Set up local proxy for llm routing

### DIFF
--- a/docs/CLAUDE_CODE_PROXY.md
+++ b/docs/CLAUDE_CODE_PROXY.md
@@ -1,0 +1,66 @@
+## Claude Code Proxy: 快速安装与配置
+
+### 目标
+- 本机无 Docker，安装并运行 `claude-code-proxy` 在 `127.0.0.1:8082`
+- 用户按向导填写 LLM 配置（OpenAI Key 等）
+- 将 Claude Code 的请求中转到本地代理
+
+### 1) 一键安装与启动（推荐）
+
+```bash
+# 安装并启动（默认端口 8082）
+bash scripts/install-claude-proxy.sh \
+  --openai-key sk-xxxx \
+  --anthropic-key my-proxy-key \
+  --port 8082
+```
+
+完成后日志位置：`~/.cache/claude-code-proxy/server.log`
+
+如需自定义目录或 Base URL：
+```bash
+bash scripts/install-claude-proxy.sh \
+  --dir "$HOME/.local/claude-code-proxy" \
+  --openai-base-url https://api.openai.com/v1 \
+  --openai-key sk-xxxx \
+  --port 8082
+```
+
+### 2) 配置 Claude Code 使用本地代理
+
+根据官方指南设置，但将 Base URL 指向本地代理。
+
+- 方式 A：仅当前终端有效
+```bash
+bash scripts/configure-claude-code.sh --anthropic-key my-proxy-key --port 8082
+```
+
+- 方式 B：持久化到 `~/.bashrc`
+```bash
+bash scripts/configure-claude-code.sh --anthropic-key my-proxy-key --port 8082 --persist
+```
+
+完成后，Claude Code 会通过 `http://127.0.0.1:8082` 中转请求。
+
+### 3) 启动 Claude Code（CLI 示例）
+```bash
+claude --model claude-3-5-sonnet-20241022
+```
+模型会被代理映射到 `.env` 中配置的 `BIG_MODEL`/`MIDDLE_MODEL`/`SMALL_MODEL`（默认 `gpt-4o` / `gpt-4o` / `gpt-4o-mini`）。
+
+### 4) 常用维护命令
+- 查看日志：
+```bash
+tail -f ~/.cache/claude-code-proxy/server.log
+```
+- 重启代理：
+```bash
+pkill -f 'uv run claude-code-proxy' || pkill -f 'uvicorn.*8082'
+source "$HOME/.local/claude-code-proxy/.env"
+nohup uv run claude-code-proxy >~/.cache/claude-code-proxy/server.log 2>&1 &
+```
+
+### 说明
+- 若 `.env` 中未设置 `ANTHROPIC_API_KEY`，客户端可用任意值作为 `ANTHROPIC_API_KEY`。
+- 若设置了 `ANTHROPIC_API_KEY`，客户端必须传入完全一致的值才可访问代理。
+- 参考配置指南：`https://claudecode.blueshirtmap.com/guide.html`

--- a/docs/CLAUDE_CODE_PROXY.md
+++ b/docs/CLAUDE_CODE_PROXY.md
@@ -99,3 +99,17 @@ powershell -ExecutionPolicy Bypass -File scripts/configure-claude-code.ps1 -Anth
 - Claude Code 未走本地代理：确认环境变量在启动 Claude Code 的同一会话中生效；GUI 启动的应用需重启或从配置脚本持久化设置。
 - 系统代理干扰：确认 `NO_PROXY/no_proxy` 包含 `localhost,127.0.0.1`。
 - 端口连接失败：检查日志 `~/.cache/claude-code-proxy/server.log`，或确认端口未被占用。
+
+## 系统体检 Doctor（推荐）
+- 打开应用，左下角点击“系统体检”，一键体检。
+- 体检范围：代理健康、uv/Python、OpenAI Key、ANTHROPIC_* 环境、NO_PROXY、端口冲突、rc 重复项。
+- 点击“应用建议修复”自动执行修复（安装/配置/拉起代理）。
+- 点击“导出诊断包”可打包日志与配置（Key 脱敏）便于排障。
+
+## 配置快照 / 回滚
+- 在右下角状态面板点击“保存快照”，会保存当前配置副本（保留最近 10 个）。
+- 点击“回滚最近”可一键恢复到上一个快照，防止误配置。
+
+### 常见问答（补充）
+- 代理不通但体检显示端口占用：说明已有进程占用端口，执行“一键修复”或更换端口后重启。
+- VS Code/终端没继承环境变量：执行“持久化”配置并重启应用/终端。

--- a/docs/CLAUDE_CODE_PROXY.md
+++ b/docs/CLAUDE_CODE_PROXY.md
@@ -64,3 +64,38 @@ nohup uv run claude-code-proxy >~/.cache/claude-code-proxy/server.log 2>&1 &
 - 若 `.env` 中未设置 `ANTHROPIC_API_KEY`，客户端可用任意值作为 `ANTHROPIC_API_KEY`。
 - 若设置了 `ANTHROPIC_API_KEY`，客户端必须传入完全一致的值才可访问代理。
 - 参考配置指南：`https://claudecode.blueshirtmap.com/guide.html`
+
+## 跨平台持久化与稳定性
+
+### 多终端持久化（Linux/macOS）
+- 当前会话：
+```bash
+bash scripts/configure-claude-code.sh --anthropic-key my-proxy-key --port 8082
+```
+- 持久化（自动更新且去重 `.bashrc`/`.zshrc`/`.profile`/`.zprofile`/`fish`）：
+```bash
+bash scripts/configure-claude-code.sh --anthropic-key my-proxy-key --port 8082 --persist
+```
+- 代理绕过：脚本会为 `NO_PROXY/no_proxy` 合并加入 `localhost,127.0.0.1`，避免系统代理影响本地回环访问。
+
+### Windows（PowerShell）
+- 当前会话：
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/configure-claude-code.ps1 -AnthropicKey my-proxy-key -Port 8082
+```
+- 持久化到用户环境变量：
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/configure-claude-code.ps1 -AnthropicKey my-proxy-key -Port 8082 -Persist
+```
+说明：持久化后需重启相关应用（如 VS Code 或终端）以加载新环境变量。
+
+### 端口占用与自动选择
+安装脚本会检测端口占用，若 `8082` 被占用，将在 `8082-8102` 范围内自动选择可用端口并写入 `.env`。对应地，请在配置脚本中使用相同端口。
+
+### 重复参数与文件冲突
+配置脚本会在 rc 文件内去重同名变量，先移除旧条目再写入新的导出，避免重复定义导致的歧义。
+
+### 典型问题排查
+- Claude Code 未走本地代理：确认环境变量在启动 Claude Code 的同一会话中生效；GUI 启动的应用需重启或从配置脚本持久化设置。
+- 系统代理干扰：确认 `NO_PROXY/no_proxy` 包含 `localhost,127.0.0.1`。
+- 端口连接失败：检查日志 `~/.cache/claude-code-proxy/server.log`，或确认端口未被占用。

--- a/llm-proxy/.env.example
+++ b/llm-proxy/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and fill values
+OPENAI_API_KEY=sk-your-openai-key
+# Optional, default is https://api.openai.com
+OPENAI_API_BASE=https://api.openai.com
+
+# Arbitrary password you set to secure the proxy
+LITELLM_MASTER_KEY=sk-your-proxy-key

--- a/llm-proxy/README.md
+++ b/llm-proxy/README.md
@@ -1,0 +1,52 @@
+## Quickstart: Local LLM Proxy for Claude Code
+
+### 1) Prepare env
+
+Copy `.env.example` to `.env` and set keys:
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
+Required:
+- `OPENAI_API_KEY`: your OpenAI key
+- `LITELLM_MASTER_KEY`: any secret to protect the gateway
+
+Optional:
+- `OPENAI_API_BASE` (default `https://api.openai.com`)
+
+### 2) Start proxy
+
+```bash
+docker compose up -d
+# or: docker-compose up -d
+```
+
+This starts LiteLLM gateway on `http://127.0.0.1:4000`.
+
+### 3) Configure Claude Code to use proxy
+
+Set Anthropic enterprise/proxy envs before starting Claude Code (VSCode or CLI):
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:4000
+export ANTHROPIC_API_KEY=${LITELLM_MASTER_KEY:-sk-your-proxy-key}
+```
+
+Then in Claude Code select the model id exposed by the proxy, e.g.:
+- `claude-3-5-sonnet-20241022`
+
+If using Claude CLI:
+
+```bash
+claude --model claude-3-5-sonnet-20241022
+```
+
+### 4) Swap backend model
+
+Edit `config.yaml` → change `litellm_params.model` to any supported backend, e.g. `openai/gpt-4o`, `openai/o3`, etc. Restart compose after changes.
+
+### Notes
+- Auth: requests must include `x-api-key: $LITELLM_MASTER_KEY` (Claude Code uses `ANTHROPIC_API_KEY`).
+- Anthropic compatibility route is enabled so Claude Code can talk to `/v1/messages`.

--- a/llm-proxy/config.yaml
+++ b/llm-proxy/config.yaml
@@ -1,0 +1,23 @@
+litellm_settings:
+  # Master key for gateway auth, read from env in docker-compose
+  master_key: os.environ/LITELLM_MASTER_KEY
+  # Enable anthropic-compatible routes
+  anthropic_compatibility: true
+
+model_list:
+  # Expose an Anthropic-style model id which Claude Code will select
+  - model_name: claude-3-5-sonnet-20241022
+    litellm_params:
+      # Route to OpenAI model here; you can swap to o3, gpt-4o, etc.
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+      api_base: os.environ/OPENAI_API_BASE
+
+# Optional: fallback examples
+# router:
+#   strategy: simple_weighted
+#   routing_table:
+#     - model_name: claude-3-5-sonnet-20241022
+#       weights:
+#         - model: openai/gpt-4o
+#           weight: 1

--- a/llm-proxy/docker-compose.yml
+++ b/llm-proxy/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:main-latest
+    container_name: litellm
+    command: ["--port", "4000", "--config", "/app/config.yaml", "--detailed_debug"]
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_API_BASE=${OPENAI_API_BASE:-https://api.openai.com}
+      - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
+    volumes:
+      - ./config.yaml:/app/config.yaml:ro
+    ports:
+      - "4000:4000"
+    restart: unless-stopped

--- a/public/site/download.html
+++ b/public/site/download.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>下载 - Claude Code Proxy Pro</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <div class="section">
+    <h1>下载</h1>
+    <p>选择你的平台。签名稍后补充，校验指纹也将一并提供。</p>
+    <div class="card">
+      <h3>Windows</h3>
+      <ul>
+        <li><a href="#">Installer (.exe) — 即将提供</a></li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3>macOS</h3>
+      <ul>
+        <li><a href="#">DMG — 即将提供</a></li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3>Linux</h3>
+      <ul>
+        <li><a href="#">AppImage/DEB/RPM — 即将提供</a></li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/site/faq.html
+++ b/public/site/faq.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FAQ - Claude Code Proxy Pro</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <div class="section">
+    <h1>FAQ</h1>
+    <div class="card">
+      <h3>需要管理员权限吗？</h3>
+      <p>默认无需。我们执行 per-user 安装与持久化；仅在极少数系统策略下可能需要权限。</p>
+    </div>
+    <div class="card">
+      <h3>公司网络/代理影响怎么办？</h3>
+      <p>应用会合并 NO_PROXY/no_proxy 加入 localhost,127.0.0.1；若仍受限，请联系网络管理员或使用 Azure OpenAI。</p>
+    </div>
+    <div class="card">
+      <h3>如何回滚配置？</h3>
+      <p>状态面板“保存快照/回滚最近”，或在设置中选择具体快照。</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Claude Code Proxy Pro</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:#0f1115;color:#e5e7eb}
+    .hero{padding:64px 24px;text-align:center}
+    .hero h1{font-size:40px;margin:0 0 12px}
+    .hero p{opacity:.8}
+    .nav{display:flex;gap:16px;justify-content:center;margin-top:24px}
+    .nav a{color:#93c5fd;text-decoration:none}
+    .section{max-width:960px;margin:0 auto;padding:24px}
+    .card{background:#111827;border:1px solid #1f2937;border-radius:12px;padding:16px;margin:12px 0}
+    .btn{background:#2563eb;color:#fff;border:none;padding:10px 16px;border-radius:8px;text-decoration:none}
+  </style>
+</head>
+<body>
+  <div class="hero">
+    <h1>Claude Code Proxy Pro</h1>
+    <p>一键安装 · 本地中转 · 强健兼容 · 系统体检与一键修复</p>
+    <div class="nav">
+      <a href="./download.html">下载</a>
+      <a href="./quickstart.html">快速开始</a>
+      <a href="./troubleshoot.html">故障排查</a>
+      <a href="./faq.html">FAQ</a>
+    </div>
+  </div>
+  <div class="section">
+    <div class="card">
+      <h3>核心特性</h3>
+      <ul>
+        <li>本地代理：将 Claude Code 请求一键指向 127.0.0.1:8082</li>
+        <li>跨平台：macOS / Windows / Linux 脚本与持久化</li>
+        <li>系统体检：一键体检、建议修复、导出诊断包</li>
+        <li>快照/回滚：配置可逆，安全试错</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/site/quickstart.html
+++ b/public/site/quickstart.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>快速开始 - Claude Code Proxy Pro</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <div class="section">
+    <h1>快速开始</h1>
+    <div class="card">
+      <h3>一键安装（应用内）</h3>
+      <ol>
+        <li>打开应用 → 安装向导 → 输入 OpenAI Key → 一键安装。</li>
+        <li>安装完成自动健康校验，显示“安装和配置已完成”。</li>
+      </ol>
+    </div>
+    <div class="card">
+      <h3>命令行（可选）</h3>
+      <pre><code>bash scripts/install-claude-proxy.sh --openai-key sk-xxxx --port 8082
+bash scripts/configure-claude-code.sh --anthropic-key my-proxy-key --port 8082 --persist
+</code></pre>
+    </div>
+    <div class="card">
+      <h3>验证代理</h3>
+      <pre><code>curl -sS http://127.0.0.1:8082/health | jq .
+</code></pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/site/style.css
+++ b/public/site/style.css
@@ -1,0 +1,7 @@
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:#0f1115;color:#e5e7eb}
+.section{max-width:960px;margin:0 auto;padding:24px}
+.card{background:#111827;border:1px solid #1f2937;border-radius:12px;padding:16px;margin:12px 0}
+a{color:#93c5fd}
+pre{background:#0b1220;border:1px solid #1f2937;border-radius:8px;padding:12px;overflow:auto}
+code{color:#cbd5e1}
+h1,h2,h3{color:#fff}

--- a/public/site/troubleshoot.html
+++ b/public/site/troubleshoot.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>故障排查 - Claude Code Proxy Pro</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <div class="section">
+    <h1>故障排查</h1>
+    <div class="card">
+      <h3>1. 代理是否在运行？</h3>
+      <pre><code>curl -sS http://127.0.0.1:8082/health | jq .
+</code></pre>
+      <p>若失败，点击应用右下角“状态面板 → 一键修复”。</p>
+    </div>
+    <div class="card">
+      <h3>2. 环境变量是否生效？</h3>
+      <pre><code>echo $ANTHROPIC_BASE_URL  # Windows PowerShell: $env:ANTHROPIC_BASE_URL
+</code></pre>
+      <p>若未指向 127.0.0.1:8082，执行：</p>
+      <pre><code>bash scripts/configure-claude-code.sh --anthropic-key my-proxy-key --port 8082 --persist
+</code></pre>
+    </div>
+    <div class="card">
+      <h3>3. 端口被占用？</h3>
+      <pre><code>lsof -iTCP -sTCP:LISTEN -P -n | grep :8082  # macOS/Linux
+netstat -ano | findstr :8082                # Windows
+</code></pre>
+      <p>应用会自动尝试在 8082-8102 选择可用端口，或在“安装脚本”中指定 --port。</p>
+    </div>
+    <div class="card">
+      <h3>4. 系统代理/公司网络影响？</h3>
+      <p>确保 NO_PROXY/no_proxy 包含 localhost,127.0.0.1（应用已自动合并），重启 VS Code/终端后重试。</p>
+    </div>
+    <div class="card">
+      <h3>导出诊断包</h3>
+      <p>应用内“系统体检 → 导出诊断包”并发送给支持人员（Key 已脱敏）。</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/vscode-style-app.js
+++ b/public/vscode-style-app.js
@@ -888,6 +888,40 @@ if (window.electronAPI) {
   } catch {}
 })();
 
+(function initSnapshotControls() {
+  try {
+    const ctr = document.getElementById('proxy-status-panel');
+    if (!ctr) return;
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.gap = '8px';
+    row.style.marginTop = '8px';
+    row.innerHTML = `
+      <button id="btn-snap">保存快照</button>
+      <button id="btn-rollback">回滚最近</button>
+    `;
+    ctr.appendChild(row);
+
+    const btnSnap = row.querySelector('#btn-snap');
+    const btnRb = row.querySelector('#btn-rollback');
+
+    btnSnap.addEventListener('click', async () => {
+      try { await window.electronAPI.createSnapshot('manual'); alert('已保存快照'); } catch {}
+    });
+    btnRb.addEventListener('click', async () => {
+      try {
+        const snaps = await window.electronAPI.listSnapshots();
+        if (snaps && snaps.length) {
+          await window.electronAPI.rollbackSnapshot(snaps[0].id);
+          alert('已回滚到最近快照');
+        } else {
+          alert('没有可回滚的快照');
+        }
+      } catch (e) { alert('回滚失败'); }
+    });
+  } catch {}
+})();
+
 (function initDoctorOverlay() {
   try {
     const btn = document.createElement('button');

--- a/scripts/configure-claude-code.ps1
+++ b/scripts/configure-claude-code.ps1
@@ -1,0 +1,46 @@
+#requires -version 5.1
+param(
+  [string]$AnthropicKey = "any-value",
+  [int]$Port = 8082,
+  [switch]$Persist
+)
+
+$baseUrl = "http://127.0.0.1:$Port"
+
+# Current session
+$env:ANTHROPIC_BASE_URL = $baseUrl
+$env:ANTHROPIC_API_KEY = $AnthropicKey
+
+Write-Host "Configured environment for Claude Code (this session):"
+Write-Host "  ANTHROPIC_BASE_URL=$($env:ANTHROPIC_BASE_URL)"
+Write-Host "  ANTHROPIC_API_KEY=$($env:ANTHROPIC_API_KEY)"
+
+# Update NO_PROXY/no_proxy to bypass localhost
+function Merge-NoProxy([string]$current) {
+  if ([string]::IsNullOrEmpty($current)) { return "localhost,127.0.0.1" }
+  $items = $current.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+  if (-not ($items -contains "localhost")) { $items += "localhost" }
+  if (-not ($items -contains "127.0.0.1")) { $items += "127.0.0.1" }
+  return ($items -join ",")
+}
+
+$env:NO_PROXY = Merge-NoProxy $env:NO_PROXY
+$env:no_proxy = Merge-NoProxy $env:no_proxy
+
+if ($Persist) {
+  # Persist to User environment
+  [Environment]::SetEnvironmentVariable("ANTHROPIC_BASE_URL", $baseUrl, "User")
+  [Environment]::SetEnvironmentVariable("ANTHROPIC_API_KEY", $AnthropicKey, "User")
+
+  $uNoProxy = [Environment]::GetEnvironmentVariable("NO_PROXY", "User")
+  $uNoProxy = Merge-NoProxy $uNoProxy
+  [Environment]::SetEnvironmentVariable("NO_PROXY", $uNoProxy, "User")
+
+  $ulNoProxy = [Environment]::GetEnvironmentVariable("no_proxy", "User")
+  $ulNoProxy = Merge-NoProxy $ulNoProxy
+  [Environment]::SetEnvironmentVariable("no_proxy", $ulNoProxy, "User")
+
+  Write-Host "Persisted User environment variables. You may need to restart apps for changes to take effect."
+}
+
+Write-Host "To run Claude Code CLI: claude --model claude-3-5-sonnet-20241022"

--- a/scripts/install-claude-proxy.ps1
+++ b/scripts/install-claude-proxy.ps1
@@ -1,0 +1,105 @@
+#requires -version 5.1
+param(
+  [string]$InstallDir = "$env:USERPROFILE\.local\claude-code-proxy",
+  [string]$OpenAIKey = "",
+  [string]$AnthropicKey = "",
+  [string]$OpenAIBaseUrl = "https://api.openai.com/v1",
+  [int]$Port = 8082,
+  [switch]$NoStart
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-PortInUse([int]$p) {
+  try {
+    $tcp = Get-NetTCPConnection -State Listen -LocalPort $p -ErrorAction SilentlyContinue
+    return $null -ne $tcp
+  } catch { return $false }
+}
+
+function Pick-FreePort([int]$start) {
+  for ($c = $start; $c -le ($start + 20); $c++) {
+    if (-not (Test-PortInUse $c)) { return $c }
+  }
+  return $start
+}
+
+function Ensure-Uv() {
+  if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Host 'Installing uv...'
+    powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+  }
+}
+
+function Replace-Or-Append([string]$file, [string]$key, [string]$value) {
+  if (-not (Test-Path $file)) { New-Item -ItemType File -Path $file -Force | Out-Null }
+  $content = Get-Content $file -ErrorAction SilentlyContinue
+  $pattern = "^$key="
+  $replaced = $false
+  $new = @()
+  foreach ($line in $content) {
+    if ($line -match $pattern) {
+      $new += "$key=\"$value\""
+      $replaced = $true
+    } else {
+      $new += $line
+    }
+  }
+  if (-not $replaced) { $new += "$key=\"$value\"" }
+  Set-Content -Path $file -Value $new -Encoding UTF8
+}
+
+# Ensure folder
+New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+
+# Ensure uv
+Ensure-Uv
+
+# Clone or update repo
+if (-not (Test-Path (Join-Path $InstallDir '.git'))) {
+  git clone https://github.com/fuergaosi233/claude-code-proxy $InstallDir
+} else {
+  try { git -C $InstallDir pull --ff-only } catch {}
+}
+
+# Sync deps
+Push-Location $InstallDir
+uv sync
+
+# Prepare .env
+$envFile = Join-Path $InstallDir '.env'
+if (-not (Test-Path $envFile)) { Copy-Item (Join-Path $InstallDir '.env.example') $envFile }
+
+if ($OpenAIKey) { Replace-Or-Append $envFile 'OPENAI_API_KEY' $OpenAIKey }
+if ($AnthropicKey) { Replace-Or-Append $envFile 'ANTHROPIC_API_KEY' $AnthropicKey }
+Replace-Or-Append $envFile 'OPENAI_BASE_URL' $OpenAIBaseUrl
+
+# Port auto-pick
+$selected = $Port
+if (Test-PortInUse $selected) {
+  $np = Pick-FreePort $selected
+  if ($np -ne $selected) { Write-Host "Port $selected busy, using $np"; $selected = $np }
+}
+Replace-Or-Append $envFile 'PORT' "$selected"
+
+Pop-Location
+
+# Start in background
+$logDir = Join-Path $env:USERPROFILE '.cache\claude-code-proxy'
+New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+$logFile = Join-Path $logDir 'server.log'
+
+if (-not $NoStart) {
+  try { Get-Process -Name uvicorn -ErrorAction SilentlyContinue | Stop-Process -Force } catch {}
+  try { Get-Process -Name python -ErrorAction SilentlyContinue | Where-Object { $_.Path -like '*uv*' } | Stop-Process -Force } catch {}
+  $envVars = Get-Content $envFile | ForEach-Object {
+    if ($_ -match '^([^=]+)="?(.*)"?$') { [Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process') }
+  }
+  Start-Process -WindowStyle Hidden -FilePath 'uv' -ArgumentList 'run claude-code-proxy' -WorkingDirectory $InstallDir -RedirectStandardOutput $logFile -RedirectStandardError $logFile
+  Write-Host "Started on http://127.0.0.1:$selected"
+  Write-Host "Logs: $logFile"
+}
+
+Write-Host "Configure Claude Code to use: ANTHROPIC_BASE_URL=http://127.0.0.1:$selected"
+if ($AnthropicKey) { Write-Host "ANTHROPIC_API_KEY=$AnthropicKey" } else { Write-Host "ANTHROPIC_API_KEY=any-value" }

--- a/src/main/main-enhanced.js
+++ b/src/main/main-enhanced.js
@@ -361,6 +361,17 @@ class ClaudeCodeProEnhanced {
             return await this.configManager.saveConfig(config);
         });
         
+        // 配置快照
+        ipcMain.handle('create-snapshot', async (event, note) => {
+            return this.configManager.createSnapshot(note || '');
+        });
+        ipcMain.handle('list-snapshots', async () => {
+            return this.configManager.getSnapshots();
+        });
+        ipcMain.handle('rollback-snapshot', async (event, snapshotId) => {
+            return this.configManager.rollbackTo(snapshotId);
+        });
+        
         // === 代理管理 ===
         ipcMain.handle('start-proxy', async (event, config) => {
             try {

--- a/src/preload/vscode-style-preload.js
+++ b/src/preload/vscode-style-preload.js
@@ -18,6 +18,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     configureClaudeEnv: (args) => ipcRenderer.invoke('configure-claude-env', args),
     verifyProxy: (port) => ipcRenderer.invoke('verify-claude-proxy', port),
     onProxyHealth: (cb) => ipcRenderer.on('proxy-health', (_e, payload) => cb(payload)),
+    // Doctor
+    runDoctor: (args) => ipcRenderer.invoke('run-doctor', args),
+    applyFix: (fixId, args) => ipcRenderer.invoke('apply-fix', fixId, args),
+    exportDiagnostics: () => ipcRenderer.invoke('export-diagnostics'),
     
     // 环境检查
     checkCommand: (command) => ipcRenderer.invoke('check-command', command),

--- a/src/preload/vscode-style-preload.js
+++ b/src/preload/vscode-style-preload.js
@@ -22,6 +22,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     runDoctor: (args) => ipcRenderer.invoke('run-doctor', args),
     applyFix: (fixId, args) => ipcRenderer.invoke('apply-fix', fixId, args),
     exportDiagnostics: () => ipcRenderer.invoke('export-diagnostics'),
+    // Snapshots
+    createSnapshot: (note) => ipcRenderer.invoke('create-snapshot', note),
+    listSnapshots: () => ipcRenderer.invoke('list-snapshots'),
+    rollbackSnapshot: (id) => ipcRenderer.invoke('rollback-snapshot', id),
     
     // 环境检查
     checkCommand: (command) => ipcRenderer.invoke('check-command', command),

--- a/src/preload/vscode-style-preload.js
+++ b/src/preload/vscode-style-preload.js
@@ -13,8 +13,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 代理管理
     startProxy: (config) => ipcRenderer.invoke('start-proxy', config),
     stopProxy: () => ipcRenderer.invoke('stop-proxy'),
-    getProxyStatus: () => ipcRenderer.invoke('get-proxy-status'),
-    testConnection: (config) => ipcRenderer.invoke('test-connection', config),
+    getConfig: () => ipcRenderer.invoke('get-config'),
+    runProxyInstaller: (args) => ipcRenderer.invoke('run-proxy-installer', args),
+    configureClaudeEnv: (args) => ipcRenderer.invoke('configure-claude-env', args),
+    verifyProxy: (port) => ipcRenderer.invoke('verify-claude-proxy', port),
+    onProxyHealth: (cb) => ipcRenderer.on('proxy-health', (_e, payload) => cb(payload)),
     
     // 环境检查
     checkCommand: (command) => ipcRenderer.invoke('check-command', command),

--- a/src/preload/wizard-preload.js
+++ b/src/preload/wizard-preload.js
@@ -52,6 +52,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 代理管理
     startProxy: (config) => ipcRenderer.invoke('start-proxy', config),
     
+    // 新增：运行一键安装脚本（跨平台）
+    runProxyInstaller: (args) => ipcRenderer.invoke('run-proxy-installer', args),
+    // 新增：配置 Claude Code 环境（持久化等）
+    configureClaudeEnv: (args) => ipcRenderer.invoke('configure-claude-env', args),
+    // 新增：校验 Python Proxy 健康状态
+    verifyProxy: (port) => ipcRenderer.invoke('verify-claude-proxy', port),
+    
     // 应用控制
     openMainApp: () => ipcRenderer.invoke('open-main-app'),
     


### PR DESCRIPTION
Add two local proxy solutions for Claude Code (Docker-based LiteLLM and non-Docker `claude-code-proxy`) to route requests to an OpenAI-compatible LLM.

Initially, a Docker-based LiteLLM solution was provided. However, the user requested a non-Docker setup, leading to the inclusion of the `claude-code-proxy` project with dedicated installation and configuration scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1f8e120-c6b9-4b30-9dab-0887bf1f179d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1f8e120-c6b9-4b30-9dab-0887bf1f179d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

